### PR TITLE
Fix: card overlap issue on about-us page

### DIFF
--- a/css/aboutus.css
+++ b/css/aboutus.css
@@ -294,11 +294,12 @@
       .content-card {
         background: white;
         border-radius: 25px;
+        margin-top: 2rem;
         padding: 3rem;
         box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
         transform: translateY(50px);
         opacity: 0;
-        transition: all 0.8s ease;
+        transition: all 0.5s ease;
       }
 
       .content-card.visible {
@@ -307,7 +308,7 @@
       }
 
       .content-card:hover {
-        transform: translateY(-10px);
+        transform: scale(1.03);
         box-shadow: 0 30px 80px rgba(0, 0, 0, 0.15);
       }
 


### PR DESCRIPTION
## 📌 Description
This pull request resolves the card overlap issue on the UI and enhances the user experience by scaling up the cards on hover.
It improves the layout consistency and interactivity, especially on different screen sizes.

## ✅ Related Issue

Closes #339 

## 🛠️ Type of Change

- [x] Bug fix 🐛
- [x] New feature ✨
## 🧪 How Has This Been Tested?

- [x] Locally

## 🖼️ Screenshots / Videos (if applicable)

<img width="1616" height="784" alt="image" src="https://github.com/user-attachments/assets/6498dacf-653f-4f32-9fa3-7efa262701f5" />


## 🧹 Code of Conduct

- [x] I have followed the contribution guidelines.
- [x] My code follows the project's code style.
- [x] I have added tests or relevant documentation if necessary.
- [x] I have linked the issue this PR solves.
- [x] I have tested the code before raising the PR.

Thank you for reviewing my contribution! Looking forward to your feedback.
