### PR TITLE
fix: Correct redirection link added in href for quiz page

### DIFF
--- a/pages/crazyfacts.html
+++ b/pages/crazyfacts.html
@@ -49,7 +49,7 @@
                         <a class="nav-link  navbarhover" href="destination.html">Hidden Destinations </a>
                     </li>
                     <li class="nav-item">
-                <a class="nav-link navbarhover" href="/pages/quiz.html"
+                <a class="nav-link navbarhover" href="quiz.html"
                   >Quiz</a
                 >
                 </ul>


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 Description

The url in href was wrong resulting in user being redirected to wrong page when clicked on quiz in navbar when in crazy facts page. That has been fixed

## ✅ Related Issue

Closes #366 

## 🛠️ Type of Change

Please delete options that are not relevant and check the box(es):

- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code style update 🎨
- [ ] Refactoring 🔨
- [ ] Documentation update 📚
- [ ] Performance improvement ⚡
- [ ] Test addition ✅
- [ ] Other (please describe): __________

## 🧪 How Has This Been Tested?

- [x] Locally
- [ ] Deployed preview
- [ ] Unit/Integration tests
- [ ] Not tested

## 🖼️ Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/d8902d21-a9b3-467e-888a-ecb51a87f90b



## 🧹 Code of Conduct

- [x] I have followed the contribution guidelines.
- [x] My code follows the project's code style.
- [x] I have added tests or relevant documentation if necessary.
- [x] I have linked the issue this PR solves.
- [x] I ran `npm run lint` or `npm run format` if applicable.
- [x] I have tested the code before raising the PR.


---

🔗 Thank you for your contribution!
