### PR TITLE
✅ Fix: "Best Time to Visit States" Page Link from Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
 
         <li>
          <div class="home-box tooltip" style="padding-top: 2px;">
-  <a href="/P2/DeshDarshan/pages/best_time.html">
+  <a href="pages/best_time.html">
     <i class="fas fa-calendar-alt fa-2x" aria-hidden="true"></i>
   </a>
   <span class="tooltiptext">See best time to travel across India</span>


### PR DESCRIPTION
### ✅ Fix: "Best Time to Visit States" Page Link from Home Page

- Corrected the link/route for the "Best Time to Visit States" section on the home page.
- Page now opens as expected on click.

Fixes: #392 
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/f5c12aa9-632c-46dc-9e9b-663e4e0f8529" />

