### PR TITLE
facts for states section layout fixed

### DIFF
--- a/pages/crazyfacts.html
+++ b/pages/crazyfacts.html
@@ -509,27 +509,86 @@
     }
 
 
+     /* GRID LAYOUT - 4 cards per row */
     .row {
-      display: flex;
-      overflow-x: auto;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr); /* Exactly 4 columns */
       gap: 20px;
       padding: 40px;
-      scroll-snap-type: x mandatory;
+     justify-items: center;
     }
 
-    .col-lg {
-      flex: 0 0 300px;
-      scroll-snap-align: start;
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 16px;
-      padding: 30px 20px;
-      backdrop-filter: blur(12px);
-      border: 1px solid rgb(201, 201, 201);
-      color: #222;
-      box-shadow: 0 8px 24px rgba(194, 194, 194, 0.1);
-      transition: transform 0.3s ease;
+/* RESPONSIVE: Adjust for smaller screens */
+@media (max-width: 1200px) {
+  .row {
+    grid-template-columns: repeat(3, 1fr); /* 3 cards on medium screens */
+  }
+}
 
-    }
+@media (max-width: 768px) {
+  .row {
+    grid-template-columns: repeat(2, 1fr); /* 2 cards on small screens */
+  }
+}
+
+@media (max-width: 480px) {
+  .row {
+    grid-template-columns: 1fr; /* 1 card on mobile */
+  }
+}
+
+.cartoon-card {
+  width: 260px;
+  min-height: 260px;
+  background: rgba(173, 216, 230, 0.3);
+  border: 1px solid rgba(173, 216, 230, 0.5);
+  border-radius: 16px;
+  padding: 20px;
+  color: #222;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+/* ICON */
+.cartoon-svg {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 15px;
+  flex-shrink: 0;
+}
+
+/* STATE NAME */
+.state-name {
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1.8;
+  margin: 0;
+  color: #1a1a1a;
+  white-space: normal;
+  word-break: break-word;
+  text-transform: capitalize;
+}
+
+/* STATE CODE */
+.state-code {
+  font-size: 14px;
+  font-weight: 500;
+  color: #666;
+}
+
+/* HOVER EFFECT */
+.cartoon-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+
+
 
     /*quiz*/
     .quiz-section {


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 Description

in this pull request i fixed the layout of the facts for state section in the crazy facts page as the older layout was not use friendly because it displayed the state facts cards in a horizontal scroll which displayed very less data and required a lot of scrolling in order to cover all the facts cards, so i made it in horizontal form in bento grid like pattern which improved readability with bigger cards and text so that it is easier for the user to read and explore facts from different different states. 

## ✅ Related Issue

Closes #478 

## 🛠️ Type of Change

Please delete options that are not relevant and check the box(es):

- [x] New feature ✨
- [x] Code style update 🎨
- [x] Refactoring 🔨
- [x] Documentation update 📚
- [x] Performance improvement ⚡

## 🧪 How Has This Been Tested?

- [x] Locally
- [ ] Deployed preview
- [x] Unit/Integration tests
- [ ] Not tested

## 🖼️ Screenshots / Videos (if applicable)

<img width="1901" height="993" alt="image" src="https://github.com/user-attachments/assets/79eda925-3405-4c51-805b-838420ba100c" />
<img width="1894" height="990" alt="Screenshot 2025-08-12 022353" src="https://github.com/user-attachments/assets/41ee7520-1ba5-4cb4-92f9-00eedc372c5f" />


## 🧹 Code of Conduct

- [x] I have followed the contribution guidelines.
- [x] My code follows the project's code style.
- [x] I have added tests or relevant documentation if necessary.
- [x] I have linked the issue this PR solves.
- [ ] I ran `npm run lint` or `npm run format` if applicable.
- [x] I have tested the code before raising the PR.



🔗 Thank you for your contribution!
