### PR TITLE
Linked Hidden Destinations to About Us page

### DIFF
--- a/pages/destination.html
+++ b/pages/destination.html
@@ -159,7 +159,7 @@
 
         <ul class="nav-menu" id="navMenu">
           <li><a href="home1.html">Home</a></li>
-          <li><a href="about us.html">About Us</a></li>
+          <li><a href="about-us.html">About Us</a></li>
           <li><a href="crazyfacts.html">Crazy Facts</a></li>
           <li><a href="exploreindia.html">Explore India</a></li>
           <li><a href="destination.html">Hidden Destinations</a></li>


### PR DESCRIPTION
This PR fixes #479 
I've made the changes and updated the link to point to the correct about us page.

https://github.com/user-attachments/assets/79303b2e-5f19-47d7-b477-3e1361d91f02

