### PR TITLE
Fix: remove extra spacing under header on Festival Calendar page (#568)

### DIFF
--- a/css/festival-calendar.css
+++ b/css/festival-calendar.css
@@ -25,7 +25,6 @@ body {
     color: white;
     text-align: center;
     padding: 100px 0 60px;
-    margin-top: 80px;
     position: relative;
     overflow: hidden;
 }


### PR DESCRIPTION
Fix: remove extra spacing under header on Festival Calendar page (#568)

Before: extra margin below header on Festival Calendar
<img width="677" height="237" alt="Screenshot 2025-08-17 011331" src="https://github.com/user-attachments/assets/a1375529-65d8-440d-88a2-de269fe95239" />

After: aligned content directly under header, consistent with other pages
<img width="2529" height="1314" alt="Screenshot 2025-08-17 011219" src="https://github.com/user-attachments/assets/dd9d6f12-135f-46dd-ab15-9efc6d7bddd8" />

