### PR TITLE
Fixed language btn going above navbar

### DIFF
--- a/pages/explore.html
+++ b/pages/explore.html
@@ -82,7 +82,7 @@
             position: absolute;
             top: 2rem;
             right: 2rem;
-            z-index: 1000;
+            z-index: -7;
         }
 
         .language-switcher select {


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 Description

In explore India page the language button was going above the navbar which I have fixed now.
It was a small bug

## ✅ Related Issue

Closes #547   
<!-- Example: Closes #42 -->

## 🛠️ Type of Change

- [x] Bug fix 🐛

## 🧪 How Has This Been Tested?

- [x] Locally

## 🖼️ Screenshots / Videos (if applicable)

before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a8abfee4-8376-44f5-af49-d72e6ceb23db" />
after
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a73df324-8a21-447d-977c-293beaf1a7b2" />


## 🧹 Code of Conduct

- [x] I have followed the contribution guidelines.
- [x] My code follows the project's code style.
- [x] I have added tests or relevant documentation if necessary.
- [x] I have linked the issue this PR solves.
- [x] I ran `npm run lint` or `npm run format` if applicable.
- [x] I have tested the code before raising the PR.

🔗 Thank you for your contribution!
