### PR TITLE
Fix tooltip/popup visibility on festival calendar hover

### DIFF
--- a/css/festival-calendar.css
+++ b/css/festival-calendar.css
@@ -204,7 +204,7 @@ body {
 .fc-event {
     background-color: #ff9933 !important;
     border-color: #ff6b35 !important;
-    color: white !important;
+    color: rgb(229, 56, 56) !important;
     border-radius: 6px;
     padding: 2px 6px;
     font-size: 0.85rem;

--- a/css/festival-calendar.css
+++ b/css/festival-calendar.css
@@ -204,7 +204,7 @@ body {
 .fc-event {
     background-color: #ff9933 !important;
     border-color: #ff6b35 !important;
-    color: rgb(229, 56, 56) !important;
+    color: white !important;
     border-radius: 6px;
     padding: 2px 6px;
     font-size: 0.85rem;
@@ -215,11 +215,12 @@ body {
 
 .fc-event:hover {
     background-color: #ff6b35 !important;
-    transform: scale(1.05);
+    transform: scale(1.08);
 }
 
 .fc-list-event:hover {
     background-color: #fff5f5 !important;
+    color: black !important;
 }
 
 /* Modal Styles */

--- a/css/festival-calendar.css
+++ b/css/festival-calendar.css
@@ -188,8 +188,10 @@ body {
     transform: translateY(-2px);
 }
 
+
 .fc-button-primary:disabled {
-    background-color: #ccc !important;
+    background-color: #6c757d !important;
+    color: white !important;
     border-color: #ccc !important;
 }
 
@@ -218,10 +220,16 @@ body {
     transform: scale(1.08);
 }
 
-.fc-list-event:hover {
-    background-color: #fff5f5 !important;
-    color: black !important;
+/* Light orange hover effect for all-day/list events in FullCalendar list view */
+.fc-list-table .fc-list-event:hover td {
+  background-color: #ffebcc  !important;
+  color: black !important;
+  cursor: pointer;
 }
+
+
+
+
 
 /* Modal Styles */
 .modal {


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 Description

This pull request fixes the issue where the event tooltip/popup on the Festival Calendar page was not visible when hovering over an event.
The fix ensures that the tooltip now appears correctly on hover, improving user experience and accessibility.

## ✅ Related Issue

Closes #679  

## 🛠️ Type of Change

- [X] Bug fix 🐛
- [X] Code style update 🎨

## 🧪 How Has This Been Tested?

- [X] Locally

## 🖼️ Screenshots

   Before: 
<img width="1542" height="618" alt="Screenshot 2025-08-27 224919" src="https://github.com/user-attachments/assets/b128cdfe-ab28-4d0b-b831-6092736a445d" />

   After:
<img width="1469" height="466" alt="image" src="https://github.com/user-attachments/assets/8bf28b78-4967-42b9-9321-f86c786cad0e" />


## 🧹 Code of Conduct

- [X] I have followed the contribution guidelines.
- [X] My code follows the project's code style.
- [X] I have linked the issue this PR solves.
- [X] I have tested the code before raising the PR.


🔗 I am raising this pull request for review. Kindly take a look and share your feedback. Waiting for your review 🙂
