### PR TITLE
Adjust dance-item height for better layout balance

### DIFF
--- a/css/dance.css
+++ b/css/dance.css
@@ -100,7 +100,7 @@ body {
   box-shadow: 0 15px 35px rgba(0,0,0,0.1);
   transition: all 0.4s ease;
   background: white;
-  height: 400px;
+  height: 350px;
 }
 
 .dance-item:hover {


### PR DESCRIPTION
📋 Pull Request
📌 Description

Updated the CSS for .dance-item by changing its height from 450px → 350px.
This improves layout balance and ensures consistent sizing across different screen sizes.

✅ Related Issue

Closes # (if there’s an issue linked, add the number here, otherwise leave blank).

🛠️ Type of Change

 Code style update 🎨


🧪 How Has This Been Tested?

 Locally (checked in browser)


🖼️ Screenshots / Videos (if applicable)

Before:
<img width="1892" height="871" alt="Screenshot 2025-09-07 213350" src="https://github.com/user-attachments/assets/06dbfdf6-0cfe-46bc-accb-f1eb67d64da1" />

After:
<img width="1507" height="774" alt="Screenshot 2025-09-07 213938" src="https://github.com/user-attachments/assets/f5a3e542-e764-4f00-8f01-270997699a1e" />

🧹 Code of Conduct

 I have followed the contribution guidelines.

 My code follows the project's code style.

 I tested the change before raising the PR.

📎 Additional Context

This is a small CSS enhancement — no breaking changes introduced.