### PR TITLE
removed duplicate fields from signup form

### DIFF
--- a/pages/signup.html
+++ b/pages/signup.html
@@ -162,30 +162,7 @@
 
 
                 <!-- Password Field -->
-                <div class="form-group">
-                    <label class="form-label" for="password">Password</label>
-                    <input type="password" id="password" name="password" class="form-input"
-                        placeholder="Create a password" required>
-                        <div id="rule" class="rule"></div>
-
-                    <!-- <span class="validation-status" id="passwordStatus"></span>
-                    <p class="error-text" id="passwordError"></p>
-                <ul id="passwordChecklist">
-        <li id="checkLength" >At least 8 characters</li>
-        <li id="checkUpper">At least 1 uppercase letter</li>
-        <li id="checkLower">At least 1 lowercase letter</li>
-        <li id="checkNumber">At least 1 number</li>
-        <li id="checkSpecial">At least 1 special character</li>
-    </ul> -->
-</div>
-                <!-- Confirm Password Field -->
-                <div class="form-group">
-                    <label class="form-label" for="confirmPassword">Confirm Password</label>
-                    <input type="password" id="confirmPassword" name="confirmPassword" class="form-input"
-                        placeholder="Confirm your password" required>
-                   <!-- <span class="validation-status" id="confirmPasswordStatus"></span> -->
-                    <div class="error-text" id="confirmPasswordError"></div>
-                </div>
+<div class="form-group">
     <label class="form-label" for="password">Password</label>
     <div class="password-wrapper" style="position: relative;">
         <input type="password" id="password" name="password" class="form-input"


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 Description
This PR fixes the form issue where Password and Confirm Password fields were duplicated, causing misalignment and unnecessary clutter.

Changes Made
Removed the duplicate set of password and confirm password fields.
Kept only the updated version with the 👁 visibility toggle button.
Preserved #rule for password validation hints and #confirmPasswordError for error messages.
Cleaned up redundant commented code for better readability.

## ✅ Related Issue

Closes #741 
<!-- Example: Closes #42 -->

## 🛠️ Type of Change
- [X] Bug fix 🐛

## 🧪 How Has This Been Tested?

- [X] Locally
- [ ] Deployed preview
- [ ] Unit/Integration tests
- [ ] Not tested

## 🖼️ Screenshots / Videos (if applicable)

Before:
<img width="618" height="897" alt="Image" src="https://github.com/user-attachments/assets/e6960429-59d2-48d7-b3c0-1dba8063e0a0" />

After:
<img width="757" height="913" alt="image" src="https://github.com/user-attachments/assets/6226a19b-3f59-40a8-8cfd-cfdb7c7f0351" />


## 🧹 Code of Conduct

- [X] I have followed the contribution guidelines.
- [X] My code follows the project's code style.
- [X] I have added tests or relevant documentation if necessary.
- [X] I have linked the issue this PR solves.
- [X] I ran `npm run lint` or `npm run format` if applicable.
- [X] I have tested the code before raising the PR.

🔗 Thank you for your contribution!
