### PR TITLE
fix: reposition language button to bottom-left on About Us page

### DIFF
--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -83,15 +83,15 @@
 
       .language-menu {
         position: absolute;
-        top: 100%;
-        right: 0;
+        bottom: 100%;
+        left: 0;
         background: white;
         border-radius: 15px;
         box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
         min-width: 200px;
         opacity: 0;
         visibility: hidden;
-        transform: translateY(-10px);
+        transform: translateY(10px);
         transition: all 0.3s ease;
         margin-top: 10px;
         overflow: hidden;


### PR DESCRIPTION
this PR addresses issue #754 

## PR Description
- Repositioned the **Languages** button to the **bottom-left corner**  
- Now the **language dropdown opens upwards**, so all options stay visible and don’t get cut off
- Matched its horizontal alignment with the chatbot button  
- Ensured it does **NOT overlap** the Signup button or any other interactive elements anymore  
- Made it fully responsive for desktop and mobile screen sizes  

---

## Visual Reference  

### Before Fix  
<img width="1919" height="218" alt="image" src="https://github.com/user-attachments/assets/e832dee6-e7b1-4bd6-b707-c926918f34d4" />

### After Fix  
<img width="1919" height="861" alt="image" src="https://github.com/user-attachments/assets/8f305a77-5dec-407a-98e9-46e3585cb298" />


### Mobile Responsiveness  
<img width="368" height="699" alt="image" src="https://github.com/user-attachments/assets/1ef40605-825b-4017-9108-03fd625d7109" />