### PR TITLE
feat: add chatbot button to Yoga page

### DIFF
--- a/pages/Yoga/yoga.css
+++ b/pages/Yoga/yoga.css
@@ -666,8 +666,8 @@
         /* Back to Top Button */
         #backToTopBtn {
             position: fixed;
-            right: 30px;
-            bottom: 30px;
+            right: 25px;
+            bottom: 85px;
             z-index: 1200;
             background: var(--primary);
             color: #fff;

--- a/pages/yoga.html
+++ b/pages/yoga.html
@@ -422,6 +422,22 @@
             });
         });
     </script>
+    <script>
+            // Chatbase loader (kept)
+    (function () {
+      if (!window.chatbase || window.chatbase("getState") !== "initialized") {
+        window.chatbase = (...arguments) => { if (!window.chatbase.q) { window.chatbase.q = []; } window.chatbase.q.push(arguments); };
+        window.chatbase = new Proxy(window.chatbase, { get(target, prop) { if (prop === "q") { return target.q } return (...args) => target(prop, ...args) } });
+      }
+      const onLoad = function () {
+        const script = document.createElement("script");
+        script.src = "https://www.chatbase.co/embed.min.js";
+        script.id = "eaZ3BLaEp3NWiit_Vn0fK";
+        document.body.appendChild(script);
+      };
+      if (document.readyState === "complete") { onLoad(); } else { window.addEventListener("load", onLoad); }
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
This PR addresses issue #769 

## Description
The Yoga page was missing the chatbot button present on all other pages. 

## This PR:
- Adds the chatbot button below the scroll-to-top button.
- Adjusts the scroll-to-top button position upward to give proper spacing between buttons.
- Ensures both buttons do not overlap and maintain responsiveness across all screen sizes.
- Matches the style, position, and behavior of the chatbot button on other pages.

### Screenshots
### Before 

<img width="377" height="228" alt="image" src="https://github.com/user-attachments/assets/b24424f3-6eb0-4239-b9df-a9e0618fb58f" />

---

## After 

<img width="376" height="247" alt="image" src="https://github.com/user-attachments/assets/f2a64007-ca99-4b53-93e0-b27385d64c95" />

---

This ensures the Yoga page now has a fully functional, non-overlapping chatbot button consistent with the rest of the site.